### PR TITLE
Pass through arbitrary structured data in bunyan log stream

### DIFF
--- a/packages/bunyan/src/bunyan.test.ts
+++ b/packages/bunyan/src/bunyan.test.ts
@@ -111,4 +111,18 @@ describe("Bunyan tests", () => {
     // Cycle through levels, and log
     levels.forEach(level => logger[level[2]](message));
   });
+
+  it("should include arbitrary extra data fields", async done => {
+    const timber = new Timber("test", "someSource");
+    timber.setSync(async logs => {
+      expect(logs).toHaveLength(1);
+      expect(logs[0].message).toEqual("i am the message");
+      expect(logs[0].foo).toEqual("bar");
+      expect(logs[0].some).toEqual({ nested: 'stuff' });
+      done();
+      return logs;
+    });
+    const logger = createLogger(timber);
+    logger.info({ foo: "bar", some: { nested: "stuff" } }, "i am the message");
+  });
 });

--- a/packages/bunyan/src/bunyan.ts
+++ b/packages/bunyan/src/bunyan.ts
@@ -14,7 +14,7 @@ export class TimberStream extends Writable {
     // Sanity check for the format of the log
     const jsonString = chunk.toString();
 
-    let log;
+    let log: any;
 
     // Should be JSON parsable
     try {
@@ -38,6 +38,11 @@ export class TimberStream extends Writable {
         meta.dt = time;
       }
     }
+
+    // Carry over any additional data fields
+    Object.keys(log)
+      .filter(key => ["time", "msg", "level", "v"].indexOf(key) < 0)
+      .forEach(key => meta[key] = log[key]);
 
     // Determine the log level
     let level: LogLevel;


### PR DESCRIPTION
Adds actual structured logging support to `@timberio/bunyan`. I considered making this behavior optional (adding a constructor parameter), but IMO it's probably what most Bunyan users would expect by default, anyway.

Fixes #61.